### PR TITLE
added .net 9, updated NuGet packages, build successful

### DIFF
--- a/Testing/Testing.csproj
+++ b/Testing/Testing.csproj
@@ -1,8 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
 
 
 


### PR DESCRIPTION
This pull request updates the project configuration in `Testing/Testing.csproj` to use a newer .NET framework version and adds several package references.

Key changes:

* Updated the target framework from `net6.0` to `net9.0`.
* Added package references for `Microsoft.AspNetCore.Mvc.NewtonsoftJson`, `Microsoft.AspNetCore.OpenApi`, and `Swashbuckle.AspNetCore`.